### PR TITLE
Add options to decide whether a request should be handled by restc

### DIFF
--- a/examples/restc-example-koa2/gateway.js
+++ b/examples/restc-example-koa2/gateway.js
@@ -1,0 +1,10 @@
+const Koa = require('koa')
+const restc = require('../..')
+const app = new Koa()
+
+app.use(restc.koa2({
+  includes: ['/api', /^\/foo/],
+  excludes: '/foobar'
+}))
+
+app.listen(3000)

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,26 +2,45 @@
 
 const fs = require('fs')
 const path = require('path')
+const Gateway = require('./utils/gateway.js')
 
 const content = fs.readFileSync(path.join(__dirname, '../faas/index.html'), 'utf-8')
 
-module.exports = options => (req, res) => {
-  // set vary header for every response
-  res.setHeader('Vary', 'Accept, Origin')
+const cache = new WeakMap()
 
-  // return if it is a cross-origin request
-  if ('origin' in req.headers) {
-    return false
+module.exports = function (options) {
+  if (cache.has(options)) {
+    return cache.get(options)
   }
 
-  // return if the client does not prefer text/html
-  let accept = req.headers.accept || ''
-  if (!/^text\/html(?:,|$)/.test(accept)) {
-    return false
+  const { includes, excludes, shouldHandle } = options
+  const gateway = new Gateway({ includes, excludes, shouldHandle })
+  const handler = function (req, res) {
+    // set vary header for every response
+    res.setHeader('Vary', 'Accept, Origin')
+
+    // return if it is a cross-origin request
+    if ('origin' in req.headers) {
+      return false
+    }
+
+    // return if the client does not prefer text/html
+    let accept = req.headers.accept || ''
+    if (!/^text\/html(?:,|$)/.test(accept)) {
+      return false
+    }
+
+    // feed the request to the gateway
+    if (!gateway.shouldHandle(req)) {
+      return false
+    }
+
+    // serve restc
+    res.send(content)
+
+    return true
   }
 
-  // serve restc
-  res.send(content)
-
-  return true
+  cache.set(options, handler)
+  return handler
 }

--- a/lib/utils/gateway.js
+++ b/lib/utils/gateway.js
@@ -1,6 +1,11 @@
 'use strict'
 
-function Gateway ({ includes, excludes, shouldHandle } = {}) {
+function Gateway (options) {
+  options = options || {}
+  let includes = options.includes
+  let excludes = options.excludes
+  const shouldHandle = options.shouldHandle
+
   if (typeof shouldHandle === 'function') {
     Object.defineProperty(this, 'shouldHandle', {
       value: shouldHandle,
@@ -30,7 +35,7 @@ Gateway.prototype.shouldHandle = function (req) {
     return false
   }
 
-  const { url } = req
+  const url = req.url
 
   if (this.excludes && this.excludes.some(rule => test(url, rule))) {
     return false

--- a/lib/utils/gateway.js
+++ b/lib/utils/gateway.js
@@ -1,0 +1,46 @@
+'use strict'
+
+function Gateway ({ includes, excludes, shouldHandle } = {}) {
+  if (typeof shouldHandle === 'function') {
+    Object.defineProperty(this, 'shouldHandle', {
+      value: shouldHandle,
+      configurable: true
+    })
+  } else {
+    if (includes && !(includes instanceof Array)) {
+      includes = [includes]
+    }
+    if (excludes && !(excludes instanceof Array)) {
+      excludes = [excludes]
+    }
+    this.includes = includes
+    this.excludes = excludes
+  }
+}
+
+Gateway.prototype.shouldHandle = function (req) {
+  const test = (url, rule) => {
+    switch (true) {
+      case typeof rule === 'string':
+        rule = rule.replace(/^\/*/, '/')
+        return url.indexOf(rule) === 0
+      case rule instanceof RegExp:
+        return rule.test(url)
+    }
+    return false
+  }
+
+  const { url } = req
+
+  if (this.excludes && this.excludes.some(rule => test(url, rule))) {
+    return false
+  }
+
+  if (this.includes && this.includes.every(rule => !test(url, rule))) {
+    return false
+  }
+
+  return true
+}
+
+module.exports = Gateway

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "index.d.ts"
   ],
   "scripts": {
-    "lint": "eslint --fix ."
+    "lint": "eslint --fix .",
+    "test": "ava"
   },
   "faas": {
     "domain": "restc",
@@ -26,6 +27,7 @@
     ]
   },
   "devDependencies": {
+    "ava": "^0.22.0",
     "eslint": "^4.2.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.7.0",

--- a/test/gateway.js
+++ b/test/gateway.js
@@ -1,0 +1,83 @@
+'use strict'
+
+const test = require('ava')
+const Gateway = require('../lib/utils/gateway')
+
+test('empty gateway should let the requests pass', t => {
+  const gateway = new Gateway()
+  t.is(gateway.shouldHandle({ url: '/' }), true)
+  t.is(gateway.shouldHandle({ url: '/foo' }), true)
+  t.is(gateway.shouldHandle({ url: '/foo/bar?baz' }), true)
+})
+
+test('gateway should only let requests that matches includes pass', t => {
+  const gateway = new Gateway({
+    includes: [
+      '/foo',
+      /^\/bar/,
+      /baz$/
+    ]
+  })
+  t.is(gateway.shouldHandle({ url: '/' }), false)
+  t.is(gateway.shouldHandle({ url: '/foo' }), true)
+  t.is(gateway.shouldHandle({ url: '/bar' }), true)
+  t.is(gateway.shouldHandle({ url: '/baz/' }), false)
+  t.is(gateway.shouldHandle({ url: '/?baz' }), true)
+})
+
+test('gateway must prevent requests that matches excludes', t => {
+  const gateway = new Gateway({
+    excludes: [
+      '/foo',
+      /^\/bar/,
+      /baz$/
+    ]
+  })
+  t.is(gateway.shouldHandle({ url: '/' }), true)
+  t.is(gateway.shouldHandle({ url: '/foo' }), false)
+  t.is(gateway.shouldHandle({ url: '/bar' }), false)
+  t.is(gateway.shouldHandle({ url: '/baz/' }), true)
+  t.is(gateway.shouldHandle({ url: '/?baz' }), false)
+})
+
+test('excludes should have higher priority over includes', t => {
+  const gateway = new Gateway({
+    includes: [
+      '/foo',
+      /^\/bar/
+    ],
+    excludes: [
+      '/bar/baz'
+    ]
+  })
+  t.is(gateway.shouldHandle({ url: '/' }), false)
+  t.is(gateway.shouldHandle({ url: '/foo' }), true)
+  t.is(gateway.shouldHandle({ url: '/bar' }), true)
+  t.is(gateway.shouldHandle({ url: '/bar/baz' }), false)
+})
+
+test('includes and excludes should process non-array properly', t => {
+  const gateway = new Gateway({
+    includes: '/foo',
+    excludes: '/foo/bar'
+  })
+  t.is(gateway.shouldHandle({ url: '/' }), false)
+  t.is(gateway.shouldHandle({ url: '/foo' }), true)
+  t.is(gateway.shouldHandle({ url: '/foo/42' }), true)
+  t.is(gateway.shouldHandle({ url: '/foo/bar' }), false)
+})
+
+test('gateway should directly call shouldHandle if provided and ignore includes and excludes', t => {
+  const gateway = new Gateway({
+    includes: '/foo',
+    excludes: [
+      '/foo/bar',
+      '/42'
+    ],
+    shouldHandle: req => req.url === '/42'
+  })
+  t.is(gateway.shouldHandle({ url: '/' }), false)
+  t.is(gateway.shouldHandle({ url: '/foo' }), false)
+  t.is(gateway.shouldHandle({ url: '/foo/42' }), false)
+  t.is(gateway.shouldHandle({ url: '/42' }), true)
+})


### PR DESCRIPTION
Relevant to #12 and #24.

## Description

1. If `shouldHandle` is given and is a function, it would be called for each request. If truthy value is returned, the request will be handled by restc; otherwise, restc will not handle the request.
2. `excludes` can be an array or a string or a RegExp. If `excludes` is given, requests that match with the value will not be handled by restc. The rules of "match with" are described as follow:
    1. If the value is a string and `req.url` starts with the value, the request is matches with the value.
    2. If the value is a RegExp and `req.url` matches with it, the request matches with the value.
    3. If the value is an array and `req.url` matches with at least one of its items, the request matches with the value.
    4. Otherwise, the request does not match with the value.
3. `includes` can be an array or a string or a RegExp. If `includes` is given, only requests that match with the value will be handled by restc. The rules of "match with" are the same as the rules above.

## Example 1:

```js
restc.koa2({
  includes: ['/api', /^\/foo/],
  excludes: '/foobar'
})
```

## Example 2:

```js
restc.koa2({
  shouldHandle: req => req.url === '/42'
})
```